### PR TITLE
Updated railties dependency.

### DIFF
--- a/simple-line-icons-rails.gemspec
+++ b/simple-line-icons-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", ">= 3.2", "<= 5.2"
+  spec.add_dependency "railties", ">= 3.2", "< 5.3"
 
   spec.add_development_dependency "activesupport"
   spec.add_development_dependency "sass-rails"


### PR DESCRIPTION
By locking the gem to version `<= 5.2` all of the patch versions will be ignored. For example, `5.2.1`. The patch version only changes for minor, backwards compatible bug-fixes. I updated to `< 5.3` instead so the gem will be compatible with Rails 5.2.x.