### PR TITLE
Add support for Rails 7.0

### DIFF
--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gemspec path: "../"
+gem "railties", "~> 7.0.0"

--- a/simple-line-icons-rails.gemspec
+++ b/simple-line-icons-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", ">= 3.2", "< 7"
+  spec.add_dependency "railties", ">= 3.2", "< 7.1"
 
   spec.add_development_dependency "activesupport"
   spec.add_development_dependency "sass-rails"


### PR DESCRIPTION
Verified it works with Rails 7.0.3.

* I added `gemfiles/rails-7.0.gemfile` for completeness sake, but I don't think it'll be of any use unless we update the `.travis.yml` version matrix which seems outdated since 2016
* I added an empty `manifest.js` file to the dummy test app in order to meet the respective sprockets requirement and allow the test suite to pass locally (`ruby -Itest test/simple_line_icons_rails_test.rb`). 